### PR TITLE
Support for DRBD resources with multiple volumes

### DIFF
--- a/qemu
+++ b/qemu
@@ -34,7 +34,7 @@ function selectDrbdDevices() {
 
 function setRole() {
   role=$1;
-  resourceName=$(echo $2 | sed -e 's|^dev="/dev/drbd/by-res/\(.*\)"|\1|');
+  resourceName=$(echo $2 | sed -e 's|^dev="/dev/drbd/by-res/\+\([^/]\+\).*\?"|\1|');
   for i in $(seq $MAX_ATTEMPTS); do
     #echo "attempt $i: drbdadm $role $resourceName" >>/var/log/libvirt/hook-qemu.log
     /sbin/drbdadm $role $resourceName && return;
@@ -46,7 +46,7 @@ function setRole() {
 
 function setDualPrimary() {
   yesno=$1
-  resourceName=$(echo $2 | sed -e 's|^dev="/dev/drbd/by-res/\(.*\)"|\1|');
+  resourceName=$(echo $2 | sed -e 's|^dev="/dev/drbd/by-res/\+\([^/]\+\).*\?"|\1|');
   for i in $(seq $MAX_ATTEMPTS); do
     #echo "attempt $i: drbdadm net-options --allow-two-primaries=$yesno $resourceName" >>/var/log/libvirt/hook-qemu.log
     /sbin/drbdadm net-options --allow-two-primaries=$yesno $resourceName && return;


### PR DESCRIPTION
* fetch only the resource name from device node path, if path also contains a volume number
* also require that the device node name must be at lease 1 character long